### PR TITLE
번역 API 적용 및 번역 결과 화면 표기 기능 적용

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,37 @@
+chrome.runtime.onMessage.addListener((message, _, response) => {
+  if (message.name === "fetchTranslate") {
+    const apiUrl = "https://openapi.naver.com/v1/papago/n2mt";
+    const clientId = "client_id";
+    const clientSecretKey = "client_secret_key";
+
+    const options = {
+      method: "POST",
+      body: new URLSearchParams({
+        source: "en",
+        target: "ko",
+        text: message.content,
+      }),
+      headers: {
+        "X-Naver-Client-Id": clientId,
+        "X-Naver-Client-Secret": clientSecretKey,
+      },
+    };
+
+    fetch(apiUrl, options)
+      .then((res) => {
+        if (res.status !== 200) {
+          response({ status: "Error", data: "error!" });
+          return;
+        }
+
+        res.json().then((data) => {
+          response({ status: "성공", data });
+        });
+      })
+      .catch(() => {
+        response({ status: "Error", data: "api 호출 중 에러" });
+      });
+  }
+
+  return true;
+});

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,9 @@
   "manifest_version": 3,
   "version": "1.0.0",
   "description": "Extension for viewing Korean subtitles and existing subtitles together",
+  "background": {
+    "service_worker": "background.js"
+  },
   "permissions": ["scripting"],
   "host_permissions": ["<all_urls>"],
   "action": {

--- a/popup.js
+++ b/popup.js
@@ -1,7 +1,7 @@
 const translationElement = document.getElementById("translate");
 
 const startApplyClosedCaption = () => {
-  const getClosedCaptionInfo = () => {
+  const getClosedCaptionInfo = async () => {
     const closedCaptionElement = document.querySelector(".vjs-text-track-cue");
     const closedCaptionWrapperElement = closedCaptionElement.parentElement;
 
@@ -10,24 +10,34 @@ const startApplyClosedCaption = () => {
     const insetStyle = closedCaptionElement.style.inset;
     const textContent = closedCaptionElement.textContent;
 
-    const newClosedCaptionWrapperElement = document.createElement("div");
+    chrome.runtime.sendMessage(
+      { name: "fetchTranslate", content: textContent },
+      (response) => {
+        if (response.data.message.result.translatedText) {
+          const newClosedCaptionWrapperElement = document.createElement("div");
 
-    newClosedCaptionWrapperElement.style.textAlign = "center";
-    newClosedCaptionWrapperElement.style.position = "absolute";
-    newClosedCaptionWrapperElement.style.width = "100%";
-    newClosedCaptionWrapperElement.style.inset = `${
-      Number(insetStyle.split(" ")[0].replace("px", "")) + 50
-    }px 0 0`;
-    newClosedCaptionWrapperElement.classList.add("vjs-text-track-cue");
+          newClosedCaptionWrapperElement.style.textAlign = "center";
+          newClosedCaptionWrapperElement.style.position = "absolute";
+          newClosedCaptionWrapperElement.style.width = "100%";
+          newClosedCaptionWrapperElement.style.inset = `${
+            Number(insetStyle.split(" ")[0].replace("px", "")) + 50
+          }px 0 0`;
+          newClosedCaptionWrapperElement.classList.add("vjs-text-track-cue");
 
-    const newClosedCaptionElement = document.createElement("div");
+          const newClosedCaptionElement = document.createElement("div");
 
-    newClosedCaptionElement.textContent = textContent;
-    newClosedCaptionElement.style.color = "rgb(255, 255, 255)";
-    newClosedCaptionElement.style.backgroundColor = "rgba(0, 0, 0, 0.8)";
+          newClosedCaptionElement.textContent =
+            response.data.message.result.translatedText;
+          newClosedCaptionElement.style.color = "rgb(255, 255, 255)";
+          newClosedCaptionElement.style.backgroundColor = "rgba(0, 0, 0, 0.8)";
 
-    newClosedCaptionWrapperElement.appendChild(newClosedCaptionElement);
-    closedCaptionWrapperElement.appendChild(newClosedCaptionWrapperElement);
+          newClosedCaptionWrapperElement.appendChild(newClosedCaptionElement);
+          closedCaptionWrapperElement.appendChild(
+            newClosedCaptionWrapperElement
+          );
+        }
+      }
+    );
   };
 
   const closedCaptionElement = document.querySelector(


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 파파고 번역 API 적용 및 번역 결과를 화면 상에 표기하도록 적용했습니다. 

- 기타 참고 문서 : https://developers.naver.com/docs/papago/papago-nmt-overview.md

## 💻 Changes

파파고 번역 API 적용 및 번역 결과 화면 상 표기하도록 로직을 추가했습니다. 443ab18
client key 는 mock 으로 대체했습니다. (추후 env 관련 설정이 완료되면 적용 예정)

## 🎥 ScreenShot or Video



https://user-images.githubusercontent.com/64253365/193613422-b2572ada-55d7-4529-98ab-c5fea2e2167b.mov




