### PR TITLE
간단한 로직 분리 적용

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1,0 +1,57 @@
+const getClosedCaptionInfo = () => {
+  const closedCaptionElement = document.querySelector(
+    ".vjs-text-track-cue"
+  ) as HTMLDivElement;
+  const closedCaptionWrapperElement =
+    closedCaptionElement.parentElement as HTMLDivElement;
+
+  if (!closedCaptionElement) return;
+
+  const insetStyle = closedCaptionElement.style.inset;
+  const textContent = closedCaptionElement.textContent;
+
+  chrome.runtime.sendMessage(
+    { name: "fetchTranslate", content: textContent },
+    (response) => {
+      if (response.data.message.result.translatedText) {
+        const newClosedCaptionWrapperElement = document.createElement("div");
+
+        newClosedCaptionWrapperElement.style.textAlign = "center";
+        newClosedCaptionWrapperElement.style.position = "absolute";
+        newClosedCaptionWrapperElement.style.width = "100%";
+        newClosedCaptionWrapperElement.style.inset = `${
+          Number(insetStyle.split(" ")[0].replace("px", "")) + 50
+        }px 0 0`;
+        newClosedCaptionWrapperElement.classList.add("vjs-text-track-cue");
+
+        const newClosedCaptionElement = document.createElement("div");
+
+        newClosedCaptionElement.textContent =
+          response.data.message.result.translatedText;
+        newClosedCaptionElement.style.color = "rgb(255, 255, 255)";
+        newClosedCaptionElement.style.backgroundColor = "rgba(0, 0, 0, 0.8)";
+
+        newClosedCaptionWrapperElement.appendChild(newClosedCaptionElement);
+        closedCaptionWrapperElement.appendChild(newClosedCaptionWrapperElement);
+      }
+    }
+  );
+};
+
+const startApplyClosedCaption = () => {
+  const closedCaptionElement = document.querySelector(
+    ".vjs-text-track-display"
+  ) as HTMLDivElement;
+
+  const observer = new MutationObserver(getClosedCaptionInfo);
+
+  const config = {
+    attributes: true,
+    childList: true,
+    characterData: true,
+  };
+
+  observer.observe(closedCaptionElement, config);
+};
+
+startApplyClosedCaption();

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -2,64 +2,6 @@ const translationElement = document.getElementById(
   "translate"
 ) as HTMLDivElement;
 
-const startApplyClosedCaption = () => {
-  const getClosedCaptionInfo = () => {
-    const closedCaptionElement = document.querySelector(
-      ".vjs-text-track-cue"
-    ) as HTMLDivElement;
-    const closedCaptionWrapperElement =
-      closedCaptionElement.parentElement as HTMLDivElement;
-
-    if (!closedCaptionElement) return;
-
-    const insetStyle = closedCaptionElement.style.inset;
-    const textContent = closedCaptionElement.textContent;
-
-    chrome.runtime.sendMessage(
-      { name: "fetchTranslate", content: textContent },
-      (response) => {
-        if (response.data.message.result.translatedText) {
-          const newClosedCaptionWrapperElement = document.createElement("div");
-
-          newClosedCaptionWrapperElement.style.textAlign = "center";
-          newClosedCaptionWrapperElement.style.position = "absolute";
-          newClosedCaptionWrapperElement.style.width = "100%";
-          newClosedCaptionWrapperElement.style.inset = `${
-            Number(insetStyle.split(" ")[0].replace("px", "")) + 50
-          }px 0 0`;
-          newClosedCaptionWrapperElement.classList.add("vjs-text-track-cue");
-
-          const newClosedCaptionElement = document.createElement("div");
-
-          newClosedCaptionElement.textContent =
-            response.data.message.result.translatedText;
-          newClosedCaptionElement.style.color = "rgb(255, 255, 255)";
-          newClosedCaptionElement.style.backgroundColor = "rgba(0, 0, 0, 0.8)";
-
-          newClosedCaptionWrapperElement.appendChild(newClosedCaptionElement);
-          closedCaptionWrapperElement.appendChild(
-            newClosedCaptionWrapperElement
-          );
-        }
-      }
-    );
-  };
-
-  const closedCaptionElement = document.querySelector(
-    ".vjs-text-track-display"
-  ) as HTMLDivElement;
-
-  const observer = new MutationObserver(getClosedCaptionInfo);
-
-  const config = {
-    attributes: true,
-    childList: true,
-    characterData: true,
-  };
-
-  observer.observe(closedCaptionElement, config);
-};
-
 translationElement.addEventListener("click", async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   const tabId = tab.id;
@@ -68,6 +10,6 @@ translationElement.addEventListener("click", async () => {
 
   chrome.scripting.executeScript({
     target: { tabId },
-    func: startApplyClosedCaption,
+    files: ["content.js"],
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
   mode: process.env.ENV || "development",
   entry: {
     popup: path.resolve(__dirname, "src", "popup.ts"),
+    content: path.resolve(__dirname, "src", "content.ts"),
     background: path.resolve(__dirname, "src", "background.ts"),
   },
   output: {


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : render 쪽 함수를 content.ts 로 분리했습니다. 비즈니스 로직을 분리하기 위한 목적입니다.

- 기타 참고 문서 : N/A

## 💻 Changes

webpack 번들링 시 content.js 를 생성할 수 있도록 entry 포인트를 추가했습니다. 973ba01

기존 popup.ts 내 렌더링 로직을 content.ts 로 분리 후 내부 로직도 함께 분리했습니다.
popup.ts 의 scripting 에서는 func 대신 파일 호출을 위한 files property 를 사용하여 content.ts 를 실행했습니다. 4a1069c

## 🎥 ScreenShot or Video

N/A


