### PR TITLE
build 시 README assets 제외

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "closed-caption-extendsion",
+  "name": "closed-caption-extension",
   "version": "1.0.0",
   "main": "popup.js",
   "repository": "https://github.com/TakhyunKim/Closed-caption-korean.git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,11 @@ module.exports = {
   plugins: [
     new CopyPlugin({
       patterns: [
-        { from: "./public/assets", to: "./assets" },
+        {
+          from: "./public/assets",
+          to: "./assets",
+          globOptions: { ignore: ["**/readme/**"] },
+        },
         { from: "./public/manifest.json", to: "./manifest.json" },
       ],
     }),


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 빌드 시 README assets 을 제외하기 위한 목적입니다.

- 기타 참고 문서 : N/A

## 💻 Changes

webpack config 설정에서 readme 폴더에 대한 assets 파일 생성을 제외하도록 추가했습니다. 21e1a6e

## 🎥 ScreenShot or Video

N/A
