### PR TITLE
View Class 의 중복 선언 DOM 개선

### DIFF
--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -1,0 +1,23 @@
+interface DOM_ATTRS {
+  // Parent element of the DOM to be translated attribute (ex: class, id ...)
+  domWrapperAttrs: string;
+  // The DOM to be translated attribute (ex: class, id ...)
+  domAttrs: string;
+}
+
+interface TRANSLATING_DOM_INFO {
+  [url: string]: DOM_ATTRS;
+}
+
+/**
+ * The key of the DOM object is host name.
+ * For example: https://(this url is key>).com
+ */
+const Dom: TRANSLATING_DOM_INFO = {
+  frontendmasters: {
+    domWrapperAttrs: ".vjs-text-track-display",
+    domAttrs: ".vjs-text-track-cue",
+  },
+};
+
+export default Dom;

--- a/src/content.ts
+++ b/src/content.ts
@@ -2,12 +2,20 @@ import View from "./view";
 import Model from "./model";
 import Controller from "./controller";
 
+import Dom from "./Dom";
 import Storage from "./Storage";
 
 import { TRANSLATE_CALL_MESSAGE, SWITCH_STORAGE_KEY } from "./const";
 
+const hostName = window.location.hostname.split(".");
+const hostUrl = hostName[hostName.length - 2];
+
 const renderTranslatedAndRender = () => {
-  const view = new View();
+  const translatedTargetElement = document.querySelector(
+    Dom[hostUrl].domAttrs
+  ) as HTMLDivElement | null;
+
+  const view = new View(translatedTargetElement);
   const model = new Model();
   const controller = new Controller(view, model);
 
@@ -15,7 +23,11 @@ const renderTranslatedAndRender = () => {
 };
 
 const deleteTranslatedElement = () => {
-  const view = new View();
+  const translatedTargetElement = document.querySelector(
+    Dom[hostUrl].domAttrs
+  ) as HTMLDivElement | null;
+
+  const view = new View(translatedTargetElement);
   const model = new Model();
   const controller = new Controller(view, model);
 
@@ -40,7 +52,7 @@ const disconnectObserver = () => {
 
 const connectClosedCaptionObserver = () => {
   const closedCaptionWrapperElement = document.querySelector(
-    ".vjs-text-track-display"
+    Dom[hostUrl].domWrapperAttrs
   ) as HTMLDivElement | null;
 
   if (!closedCaptionWrapperElement) return;
@@ -61,11 +73,11 @@ const disconnectClosedCaptionObserver = () => {
 };
 
 const initialSetRenderClosedCaption = async () => {
-  const { isChecked } = await Storage.getStorageValue(SWITCH_STORAGE_KEY);
+  const { isChecked } = await Storage.getStorageValue<boolean>(
+    SWITCH_STORAGE_KEY
+  );
 
-  if (typeof isChecked === "boolean" && isChecked) {
-    connectClosedCaptionObserver();
-  }
+  if (isChecked) connectClosedCaptionObserver();
 };
 
 chrome.runtime.onMessage.addListener(

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -1,16 +1,18 @@
 class View {
+  targetOfTranslatingElement: HTMLDivElement | null;
+
+  constructor(targetOfTranslatingElement: HTMLDivElement | null) {
+    this.targetOfTranslatingElement = targetOfTranslatingElement;
+  }
+
   render(closedCaptionText: string) {
-    const closedCaptionElement = document.querySelector(
-      ".vjs-text-track-cue"
-    ) as HTMLDivElement;
+    if (!this.targetOfTranslatingElement) return;
 
-    if (!closedCaptionElement) return;
-
-    const closedCaptionParentElement =
-      closedCaptionElement.parentElement as HTMLDivElement;
+    const closedCaptionParentElement = this.targetOfTranslatingElement
+      .parentElement as HTMLDivElement;
 
     const newClosedCaptionWrapperElement =
-      this.createClosedCaptionWrapperElement();
+      this.createClosedCaptionWrapperElement(this.targetOfTranslatingElement);
 
     const newClosedCaptionElement =
       this.createClosedCaptionTextElement(closedCaptionText);
@@ -19,28 +21,14 @@ class View {
     closedCaptionParentElement.appendChild(newClosedCaptionWrapperElement);
   }
 
-  getClosedCaptionElement() {
-    const closedCaptionElement = document.querySelector(
-      ".vjs-text-track-cue"
-    ) as HTMLDivElement | null;
-
-    return closedCaptionElement;
-  }
-
   getTextContent() {
-    const closedCaptionElement = document.querySelector(
-      ".vjs-text-track-cue"
-    ) as HTMLDivElement | null;
-
-    return closedCaptionElement?.textContent ?? undefined;
+    return this.targetOfTranslatingElement?.textContent ?? undefined;
   }
 
-  createClosedCaptionWrapperElement(): HTMLDivElement {
-    const closedCaptionElement = document.querySelector(
-      ".vjs-text-track-cue"
-    ) as HTMLDivElement;
-
-    const insetStyle = closedCaptionElement.style.inset;
+  createClosedCaptionWrapperElement(
+    targetClosedCaptionElement: HTMLDivElement
+  ): HTMLDivElement {
+    const insetStyle = targetClosedCaptionElement.style.inset;
 
     const newClosedCaptionWrapperElement = document.createElement("div");
 
@@ -50,7 +38,7 @@ class View {
     newClosedCaptionWrapperElement.style.inset = `${
       Number(insetStyle.split(" ")[0].replace("px", "")) + 50
     }px 0 0`;
-    newClosedCaptionWrapperElement.classList.add("vjs-text-track-cue");
+
     newClosedCaptionWrapperElement.setAttribute("id", "text-track");
 
     return newClosedCaptionWrapperElement;


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : View Class 내에서 중복으로 선언되는 Translated Target dom 관련 로직을 개선했습니다.

- 기타 참고 문서 : N/A

## 💻 Changes

View Class 에 반복되어 선언한 translated Target dom 에 대한 선언을 constructor 를 통해 전달 받는 방식으로
변경했습니다. ea7f8ac

추후 익스텐션 적용 범위 확장을 위해 frontend masters 기준으로 하드 코딩된 부분을 분리했습니다.
각 사이트 별 host name 기준으로 객체를 생성하여 필요한 dom 정보를 입력하는 방식입니다.

## 🎥 ScreenShot or Video

N/A
