### PR TITLE
View Class 중복 선언 DOM 리팩토링 [Class 에 대한 고민 작성]

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -10,27 +10,15 @@ import { TRANSLATE_CALL_MESSAGE, SWITCH_STORAGE_KEY } from "./const";
 const hostName = window.location.hostname.split(".");
 const hostUrl = hostName[hostName.length - 2];
 
+const view = new View(Dom[hostUrl].domAttrs);
+const model = new Model();
+const controller = new Controller(view, model);
+
 const renderTranslatedAndRender = () => {
-  const translatedTargetElement = document.querySelector(
-    Dom[hostUrl].domAttrs
-  ) as HTMLDivElement | null;
-
-  const view = new View(translatedTargetElement);
-  const model = new Model();
-  const controller = new Controller(view, model);
-
   controller.translatedAndRender();
 };
 
 const deleteTranslatedElement = () => {
-  const translatedTargetElement = document.querySelector(
-    Dom[hostUrl].domAttrs
-  ) as HTMLDivElement | null;
-
-  const view = new View(translatedTargetElement);
-  const model = new Model();
-  const controller = new Controller(view, model);
-
   controller.deleteTranslatedElement();
 };
 

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,5 +1,5 @@
-import type View from "../view";
-import type Model from "../model";
+import View from "../view";
+import Model from "../model";
 
 class Controller {
   _view: View;
@@ -11,6 +11,8 @@ class Controller {
   }
 
   translatedAndRender() {
+    this._view.setTargetOfTranslatingElement();
+
     const textContent = this._view.getTextContent();
 
     if (!textContent) return;

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -1,8 +1,10 @@
 class View {
+  domAttr: string;
   targetOfTranslatingElement: HTMLDivElement | null;
 
-  constructor(targetOfTranslatingElement: HTMLDivElement | null) {
-    this.targetOfTranslatingElement = targetOfTranslatingElement;
+  constructor(domAttr: string) {
+    this.domAttr = domAttr;
+    this.targetOfTranslatingElement = null;
   }
 
   render(closedCaptionText: string) {
@@ -19,6 +21,14 @@ class View {
 
     newClosedCaptionWrapperElement.appendChild(newClosedCaptionElement);
     closedCaptionParentElement.appendChild(newClosedCaptionWrapperElement);
+  }
+
+  setTargetOfTranslatingElement() {
+    const targetOfTranslatingElement = document.querySelector(
+      this.domAttr
+    ) as HTMLDivElement | null;
+
+    this.targetOfTranslatingElement = targetOfTranslatingElement;
   }
 
   getTextContent() {


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 기존 번역 대상 DOM 을 View constructor 로 전달하는 방식에서 
            해당 페이지에서 해당되는 dom attr 을 전달하는 방식으로 변경했습니다.
            이를 통해 observer 트래킹 DOM 이 변경될 때마다 매번 인스턴스를 생성하는 방식을 개선하고자 했습니다.

- 기타 참고 문서 : N/A

## 💻 Changes

View Class 에서 `번역 대상 DOM` 을 전달 받는 방식에서 `번역 대상 DOM 의 attr` 을 전달받는 방식으로 변경했습니다. 2969be1

View Class 변경 사항을 content 에 적용했습니다. 7a30444
observer 가 트래킹 하는 DOM 이 변경될 때마다 View, Model, Controller 인스턴스를 매번 생성하는 방식에서
한 번 생성한 인스턴스를 활용하는 방식으로 개선했습니다. 

## 🎥 ScreenShot or Video

N/A

## 해당 PR 내 작업 내 고민

Class 를 사용할 경우 constructor 로 사용할 값들을 전달하는데,
이게 외부 요소에 의해 변하거나, 객체 내 field 가 변하는 경우 그걸 전달하는 방식이 좋지 않는 것 같다는 생각이 듭니다.

계속 변경되는 DOM 을 전달할 경우 아래와 같은 문제가 있었습니다.

### 처음 인스턴스 생성을 위해 선언할 때 넘겨주는 DOM 은 null 이라 크게 의미가 없다.

위 내용처럼 보통 처음 웹사이트를 접근했을 때 번역에 필요한 DOM 객체는 존재하지 않습니다.
반면 인스턴스를 처음 생성한 시점은 처음 웹사이트를 접근했을 때이므로 이 방식을 사용하는 의미가 적었습니다.
물론 View Class 내 반복적으로 선언한 코드를 줄일 수 있다는 점에서 효과가 있었지만,
실제 constructor 로 넘기는 이유는 초기값을 설정 후 내부적으로 활용하는 목적도 있다고 생각합니다.
그런 점에선 처음 넘기는 DOM 은 큰 의미가 없습니다.

### 그래서 어떻게 변경했는가?

위 문제를 생각하니 지속적으로 변경되는 값을 굳이 constructor 로 전달할 필요성을 느끼지 못했고,
변하지 않는 상수값인 해당 DOM 의 attr 을 넘겨주는 방식을 선택했습니다.

Controller render method 호출 시 View 의 `setTargetOfTranslatingElement` 을 호출하여
View 초기 선언 시 전달한 attr 을 통해 객체를 셋업한 후 기존 render 로직을 돌렸습니다.
이 과정과 함께 content 에서 반복적으로 인스턴스를 생성하는 대신,
초기 한 번만 생성한 후 내부 method 만을 호출하는 방식으로 변경했습니다.

이는 이전 방법에서도 가능했습니다. `setTargetOfTranslatingElement` 을 Controller 내부에서
계속 호출하면 DOM 을 계속 갱신한다는 점은 같기 때문입니다.

그러나 `constructor` 로 전달하는 값의 의미에서 차이가 있다고 판단하여 지금과 같이 변경했습니다.

이전 View 개선 PR: https://github.com/TakhyunKim/Closed-caption-korean/pull/23
