### PR TITLE
자막 스타일 적용 방식 변경 반영 🎨

### DIFF
--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -31,36 +31,12 @@ class View {
     return this.targetOfTranslatingElement?.textContent ?? undefined;
   }
 
-  createClosedCaptionStyle(targetClosedCaptionElement: HTMLDivElement) {
-    const elementPosition = targetClosedCaptionElement.getBoundingClientRect();
-    const closedCaptionYPosition = elementPosition.bottom - 50;
-
-    return { bottom: closedCaptionYPosition };
-  }
-
-  createClosedCaptionWrapperElement(
-    targetClosedCaptionElement: HTMLDivElement
-  ): HTMLDivElement {
-    const closedCaptionStyle = this.createClosedCaptionStyle(
-      targetClosedCaptionElement
-    );
-
-    const newClosedCaptionWrapperElement = document.createElement("div");
-
-    newClosedCaptionWrapperElement.style.textAlign = "center";
-    newClosedCaptionWrapperElement.style.position = "absolute";
-    newClosedCaptionWrapperElement.style.width = "100%";
-    newClosedCaptionWrapperElement.style.bottom =
-      closedCaptionStyle.bottom.toString();
-    newClosedCaptionWrapperElement.setAttribute("id", "text-track");
-
-    return newClosedCaptionWrapperElement;
-  }
-
   createClosedCaptionTextElement(text: string): HTMLDivElement {
     const newClosedCaptionElement = document.createElement("div");
 
     newClosedCaptionElement.textContent = text;
+    newClosedCaptionElement.setAttribute("id", "text-track");
+
     newClosedCaptionElement.style.color = "rgb(255, 255, 255)";
     newClosedCaptionElement.style.backgroundColor = "rgba(0, 0, 0, 0.8)";
 

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -35,20 +35,27 @@ class View {
     return this.targetOfTranslatingElement?.textContent ?? undefined;
   }
 
+  createClosedCaptionStyle(targetClosedCaptionElement: HTMLDivElement) {
+    const elementPosition = targetClosedCaptionElement.getBoundingClientRect();
+    const closedCaptionYPosition = elementPosition.bottom - 50;
+
+    return { bottom: closedCaptionYPosition };
+  }
+
   createClosedCaptionWrapperElement(
     targetClosedCaptionElement: HTMLDivElement
   ): HTMLDivElement {
-    const insetStyle = targetClosedCaptionElement.style.inset;
+    const closedCaptionStyle = this.createClosedCaptionStyle(
+      targetClosedCaptionElement
+    );
 
     const newClosedCaptionWrapperElement = document.createElement("div");
 
     newClosedCaptionWrapperElement.style.textAlign = "center";
     newClosedCaptionWrapperElement.style.position = "absolute";
     newClosedCaptionWrapperElement.style.width = "100%";
-    newClosedCaptionWrapperElement.style.inset = `${
-      Number(insetStyle.split(" ")[0].replace("px", "")) + 50
-    }px 0 0`;
-
+    newClosedCaptionWrapperElement.style.bottom =
+      closedCaptionStyle.bottom.toString();
     newClosedCaptionWrapperElement.setAttribute("id", "text-track");
 
     return newClosedCaptionWrapperElement;

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -13,14 +13,10 @@ class View {
     const closedCaptionParentElement = this.targetOfTranslatingElement
       .parentElement as HTMLDivElement;
 
-    const newClosedCaptionWrapperElement =
-      this.createClosedCaptionWrapperElement(this.targetOfTranslatingElement);
-
     const newClosedCaptionElement =
       this.createClosedCaptionTextElement(closedCaptionText);
 
-    newClosedCaptionWrapperElement.appendChild(newClosedCaptionElement);
-    closedCaptionParentElement.appendChild(newClosedCaptionWrapperElement);
+    closedCaptionParentElement.appendChild(newClosedCaptionElement);
   }
 
   setTargetOfTranslatingElement() {

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -10,13 +10,12 @@ class View {
   render(closedCaptionText: string) {
     if (!this.targetOfTranslatingElement) return;
 
-    const closedCaptionParentElement = this.targetOfTranslatingElement
-      .parentElement as HTMLDivElement;
+    this.setClosedCaptionStyle(this.targetOfTranslatingElement);
 
     const newClosedCaptionElement =
       this.createClosedCaptionTextElement(closedCaptionText);
 
-    closedCaptionParentElement.appendChild(newClosedCaptionElement);
+    this.targetOfTranslatingElement.appendChild(newClosedCaptionElement);
   }
 
   setTargetOfTranslatingElement() {
@@ -31,6 +30,13 @@ class View {
     return this.targetOfTranslatingElement?.textContent ?? undefined;
   }
 
+  setClosedCaptionStyle(closedCaptionElement: HTMLDivElement) {
+    closedCaptionElement.style.display = 'flex';
+    closedCaptionElement.style.flexDirection = 'column';
+    closedCaptionElement.style.justifyContent = 'center';
+    closedCaptionElement.style.alignItems = 'center';
+  }
+
   createClosedCaptionTextElement(text: string): HTMLDivElement {
     const newClosedCaptionElement = document.createElement("div");
 
@@ -38,6 +44,7 @@ class View {
     newClosedCaptionElement.setAttribute("id", "text-track");
 
     newClosedCaptionElement.style.color = "rgb(255, 255, 255)";
+    newClosedCaptionElement.style.marginTop = '10px';
     newClosedCaptionElement.style.backgroundColor = "rgba(0, 0, 0, 0.8)";
 
     return newClosedCaptionElement;


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 기존 자막 스타일은 Frontend masters 에만 적용되어 사용 가능합니다.
            이를 다른 사이트에도 개별적으로 적용 가능하도록 수정했습니다. 

- 기타 참고 문서 : N/A

## 💻 Changes

자막 대상의 상위 DOM 에 새로운 자막을 추가하는 방식 대신
자막 대상 DOM 와 같은 레벨에 DOM 을 추가하는 방식으로 수정했습니다. f06351b
(이를 통해 동일한 스타일을 공유할 수 있습니다.)

불필요한 스타일 지정 method 를 삭제했습니다. 735f514

자막을 감싸는 Dom 의 스타일을 지정해주는 method 를 추가했습니다.
이전 환경과 달리 새로 번역된 Dom 도 추가되었고 해당 Dom 을 기존 자막 아래에 위치하기 위해
별도의 스타일을 추가했습니다. b31f207


## 🎥 ScreenShot or Video
<img width="910" alt="스크린샷 2022-11-24 오후 8 24 00" src="https://user-images.githubusercontent.com/64253365/203772568-c8270013-6f05-4b08-84c4-8fa4cced855a.png">


