### PR TITLE
번역 익스텐션 Udemy 지원 🎉

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -17,7 +17,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://frontendmasters.com/*"],
+      "matches": ["*://frontendmasters.com/*", "*://www.udemy.com/*"],
       "js": ["content.js"]
     }
   ],

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -18,6 +18,10 @@ const Dom: TRANSLATING_DOM_INFO = {
     domWrapperAttrs: ".vjs-text-track-display",
     domAttrs: ".vjs-text-track-cue",
   },
+  udemy: {
+    domWrapperAttrs: ".captions-display--captions-container--1-aQJ",
+    domAttrs: ".captions-display--captions-cue-text--ECkJu",
+  },
 };
 
 export default Dom;

--- a/src/content.ts
+++ b/src/content.ts
@@ -14,7 +14,7 @@ const view = new View(Dom[hostUrl].domAttrs);
 const model = new Model();
 const controller = new Controller(view, model);
 
-const renderTranslatedAndRender = () => {
+const renderTranslatedElement = () => {
   controller.translatedAndRender();
 };
 
@@ -46,7 +46,7 @@ const connectClosedCaptionObserver = () => {
   if (!closedCaptionWrapperElement) return;
 
   // render initial translated Element
-  renderTranslatedAndRender();
+  renderTranslatedElement();
 
   // connect closed caption wrapper element observer
   connectObserver(closedCaptionWrapperElement);

--- a/src/content.ts
+++ b/src/content.ts
@@ -22,7 +22,13 @@ const deleteTranslatedElement = () => {
   controller.deleteTranslatedElement();
 };
 
-const observer = new MutationObserver(renderTranslatedAndRender);
+const renderTranslatedElementAndSetObserver = () => {
+  connectClosedCaptionTargetElementObserver();
+
+  controller.translatedAndRender();
+};
+
+const observer = new MutationObserver(renderTranslatedElementAndSetObserver);
 
 const connectObserver = (element: Element) => {
   const observerOptions: MutationObserverInit = {
@@ -36,6 +42,14 @@ const connectObserver = (element: Element) => {
 
 const disconnectObserver = () => {
   observer.disconnect();
+};
+
+const connectClosedCaptionTargetElementObserver = () => {
+  const closedCaptionElement = document.querySelector(Dom[hostUrl].domAttrs);
+
+  if (!closedCaptionElement) return;
+
+  connectObserver(closedCaptionElement);
 };
 
 const connectClosedCaptionObserver = () => {

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -10,17 +10,38 @@ class Controller {
     this._model = model;
   }
 
+  compareIsSameTargetOfTranslatingText() {
+    const textContent = this._view.getTextContent();
+    const prevTargetOfTranslatingText =
+      this._model.getTargetOfTranslatingText();
+
+    return textContent === prevTargetOfTranslatingText;
+  }
+
+  checkIsSameTargetElementAndText() {
+    const translatedElement = this._view.getTranslatedElement();
+    const isSameTargetOfTranslatingText =
+      this.compareIsSameTargetOfTranslatingText();
+
+    return translatedElement && isSameTargetOfTranslatingText;
+  }
+
   translatedAndRender() {
     this._view.setTargetOfTranslatingElement();
 
+    const isSameTargetElementAndText = this.checkIsSameTargetElementAndText();
+
     const textContent = this._view.getTextContent();
 
-    if (!textContent) return;
+    if (!textContent || isSameTargetElementAndText) return;
 
-    this._model.getTranslatedText(
-      textContent,
-      this._view.render.bind(this._view)
-    );
+    const deletePrevElementEndRender = (translatedText: string) => {
+      // delete prev closed caption element
+      this._view.deleteClosedCaptionElement();
+      this._view.render.call(this._view, translatedText);
+    };
+
+    this._model.getTranslatedText(textContent, deletePrevElementEndRender);
   }
 
   deleteTranslatedElement() {

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -4,6 +4,20 @@ import type {
 } from "./types";
 
 class Model {
+  targetOfTranslatingText: string;
+
+  constructor() {
+    this.targetOfTranslatingText = "";
+  }
+
+  getTargetOfTranslatingText() {
+    return this.targetOfTranslatingText;
+  }
+
+  setTargetOfTranslatingText(targetOfTranslatingText: string) {
+    this.targetOfTranslatingText = targetOfTranslatingText;
+  }
+
   getTranslatedText(
     translateTargetText: string,
     callback: (translatedText: string) => void
@@ -13,7 +27,10 @@ class Model {
       ChromeTranslateAPIResponse
     >({ name: "translate", payload: translateTargetText }, (response) => {
       const translatedText = response.data;
+
       if (!translatedText || response.error) return;
+
+      this.setTargetOfTranslatingText(translateTargetText);
 
       callback(translatedText);
     });

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -50,6 +50,14 @@ class View {
     return newClosedCaptionElement;
   }
 
+  getTranslatedElement() {
+    const translatedElement = document.getElementById(
+      "text-track"
+    ) as HTMLDivElement | null;
+
+    return translatedElement;
+  }
+
   deleteClosedCaptionElement() {
     const targetClosedCaptionElement = document.getElementById(
       "text-track"

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -27,14 +27,16 @@ class View {
   }
 
   getTextContent() {
-    return this.targetOfTranslatingElement?.textContent ?? undefined;
+    return (
+      this.targetOfTranslatingElement?.firstChild?.textContent ?? undefined
+    );
   }
 
   setClosedCaptionStyle(closedCaptionElement: HTMLDivElement) {
-    closedCaptionElement.style.display = 'flex';
-    closedCaptionElement.style.flexDirection = 'column';
-    closedCaptionElement.style.justifyContent = 'center';
-    closedCaptionElement.style.alignItems = 'center';
+    closedCaptionElement.style.display = "flex";
+    closedCaptionElement.style.flexDirection = "column";
+    closedCaptionElement.style.justifyContent = "center";
+    closedCaptionElement.style.alignItems = "center";
   }
 
   createClosedCaptionTextElement(text: string): HTMLDivElement {
@@ -44,7 +46,7 @@ class View {
     newClosedCaptionElement.setAttribute("id", "text-track");
 
     newClosedCaptionElement.style.color = "rgb(255, 255, 255)";
-    newClosedCaptionElement.style.marginTop = '10px';
+    newClosedCaptionElement.style.marginTop = "10px";
     newClosedCaptionElement.style.backgroundColor = "rgba(0, 0, 0, 0.8)";
 
     return newClosedCaptionElement;


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : [udemy](https://www.udemy.com/) 지원을 위한 Dom 정보 추가 및 내부 로직 개선을 진행했습니다.

- 기타 참고 문서 : https://developer.mozilla.org/ko/docs/Web/API/MutationObserver

## 💻 Changes

manifest, Dom 객체 정보에 udemy 를 추가했습니다. f6bf11d

현재 번역 대상 텍스트 값을 model 이 관리하도록 value 및 set Value method 를 추가했습니다. b0bc6de

View 에서 번역 대상 텍스트와 Model 에서 이전에 번역된 값을 확인하여 비교하는 method 를
Controller 에 추가했습니다. 이전에 번역된 값과 현재 번역하고자 하는 값이 동일할 경우,
early return 처리하여 번역을 하지 않습니다.

이와 더불어 새로운 Dom 을 추가할 때 이전에 추가한 Dom 을 삭제하는 로직도 추가했습니다. 245d6d7
> 이전에 조치하지 않은 이유?
- Frontend masters 에서는 상위 Dom 에서 하위 Dom 을 삭제하는 방향으로 진행했기에
   굳이 이전 Dom 에 대한 삭제 로직이 없어도 동작했습니다.
- 이번 udemy 지원하면서 하위 DOM 이 사라지지 않아 계속 추가되는 이슈가 있어
   위와 같은 삭제 로직을 추가했습니다.
   
상위 Dom 아래에 존재하는 하위 Dom(번역 대상 Dom)에 대한 observer 도 추가했습니다.
이는 상위 Dom 이 변경되지 않고 하위 Dom 의 text 만 변경하는 방식인 사이트를 지원하기 위해
선택한 방법입니다.

[MutationObserver Mdn 문서](https://developer.mozilla.org/ko/docs/Web/API/MutationObserver)에서 동일한 Dom 를 여러번 관찰한다고 해서 여러번 observer callback 이 호출되는 것이 아니라는 comment 를 확인
위와 같이 상위 observer 가 갱신 되었을 때 하위 Dom 에 대한 observer 를 등록하는 방식을 선택했습니다. 9a22e68
(best 방법은 아닌 듯 하여 추후 개선이 필요합니다. 🥺)

[이전 PR 인 자막 스타일 적용 방식 변경](https://github.com/TakhyunKim/Closed-caption-korean/pull/26)에서 번역 대상 Dom 하위에 바로 번역된 Dom 을 추가하는 방식으로 
변경했습니다. 
이로 인해 기존 textContent 를 얻는 method 의 값이 `번역 전 값` + `번역 후 값` 이 함께 표기되는
의도에 맞지 않는 동작을 확인할 수 있었습니다.
이를 기존 의도처럼 `번역 전 값`을 얻고자 firstChild 의 textContent 를 얻는 방향으로 수정했습니다. 63dfcc4

## 🎥 ScreenShot or Video
<img width="1620" alt="스크린샷 2022-11-28 오후 6 34 40" src="https://user-images.githubusercontent.com/64253365/204243432-787797fb-bbb7-48b3-aae5-318fa3a5a5cb.png">

