### PR TITLE
일부 텍스트 번역을 누락하는 버그 수정 🛠

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,8 +1,6 @@
 chrome.runtime.onMessage.addListener((message, _, response) => {
   if (message.name === "translate") {
-    const apiURL = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=ko&dt=t&q=${encodeURIComponent(
-      message.payload
-    )}`;
+    const apiURL = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=ko&dt=t&q=${message.payload}`;
 
     fetch(apiURL)
       .then((res) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,13 @@
+const replaceNewLineSequenceToSpace = (text: string) => {
+  return text.replace(/\r?\n/g, " ");
+};
+
 chrome.runtime.onMessage.addListener((message, _, response) => {
   if (message.name === "translate") {
-    const apiURL = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=ko&dt=t&q=${message.payload}`;
+    const translateTargetText = encodeURIComponent(
+      replaceNewLineSequenceToSpace(message.payload)
+    );
+    const apiURL = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=ko&dt=t&q=${translateTargetText}`;
 
     fetch(apiURL)
       .then((res) => {


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 번역 텍스트에 `\n` [개행]이 있을 경우 개행 시그니처 뒤에 text 를 번역하지 않는 버그를 수정합니다.

- 기타 참고 문서 : N/A

## 💻 Changes

`\n` 을 빈 공란으로 치환하는 함수를 background 내 번역 함수에 적용했습니다. f353db8

## 🎥 ScreenShot or Video

N/A