### PR TITLE
번역 익스텐션 Youtube 지원

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -17,7 +17,11 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://frontendmasters.com/*", "*://www.udemy.com/*"],
+      "matches": [
+        "*://frontendmasters.com/*",
+        "*://www.udemy.com/*",
+        "*://www.youtube.com/*"
+      ],
       "js": ["content.js"]
     }
   ],

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -22,6 +22,10 @@ const Dom: TRANSLATING_DOM_INFO = {
     domWrapperAttrs: ".captions-display--captions-container--1-aQJ",
     domAttrs: ".captions-display--captions-cue-text--ECkJu",
   },
+  youtube: {
+    domWrapperAttrs: ".ytp-caption-window-container",
+    domAttrs: ".captions-text",
+  },
 };
 
 export default Dom;

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -27,9 +27,19 @@ class View {
   }
 
   getTextContent() {
-    return (
-      this.targetOfTranslatingElement?.firstChild?.textContent ?? undefined
-    );
+    if (!this.targetOfTranslatingElement) return;
+
+    const list = Array.from(this.targetOfTranslatingElement.children);
+    let textContent = "";
+
+    list.forEach((element) => {
+      // Translated subtitles are not included in the textContent.
+      if (element.id === "text-track") return;
+
+      textContent += `${element.textContent} `;
+    });
+
+    return textContent;
   }
 
   setClosedCaptionStyle(closedCaptionElement: HTMLDivElement) {


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : youtube 지원을 위한 Dom 정보 추가 및 내부 로직 개선을 진행했습니다.

- 기타 참고 문서 : N/A

## 💻 Changes

youtube Dom 정보 추가 및 접근 권한 주소에 추가 7317b25

번역 대상 Dom 의 첫번째 Node textContents 만 가져오는 방식에서
번역 대상 Dom 하위 Element 에서 text-track id 를 가지고 있는  번역된 Dom 을 제외한
나머지 Dom textContents 를 가져오는 방식으로 수정했습니다.

## 🎥 ScreenShot or Video

https://user-images.githubusercontent.com/64253365/205428814-8268be1b-ac4b-4fbf-af4e-f2c47e7a9de0.mov



