### PR TITLE
유데미 번역 대상 자막 가져오는 로직 개선

### DIFF
--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -32,6 +32,13 @@ class View {
     const list = Array.from(this.targetOfTranslatingElement.children);
     let textContent = "";
 
+    if (
+      list.length === 0 &&
+      this.targetOfTranslatingElement.firstChild?.textContent
+    ) {
+      return this.targetOfTranslatingElement.firstChild.textContent;
+    }
+
     list.forEach((element) => {
       // Translated subtitles are not included in the textContent.
       if (element.id === "text-track") return;


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 이전 text 가져오는 방식이 udemy 에는 지원하지 않아 대응이 가능한 로직을 추가했습니다.

- 기타 참고 문서 : N/A

## 💻 Changes

이전 번역 대상 Element 의 first child text content 를 가져왔습니다. 41c6a39

## 🎥 ScreenShot or Video

N/A
