### PR TITLE
번역 가능 언어 확장 기능 구현 🎉

### DIFF
--- a/public/popup.css
+++ b/public/popup.css
@@ -1,3 +1,44 @@
+.popup_wrapper {
+  display: flex;
+  justify-content: center;
+  height: 165px;
+  max-height: 165px;
+  margin: -10px;
+  background-color: #21211f;
+  color: #ffffff;
+}
+
+.translate_controller {
+  height: 100%;
+  max-height: 165px;
+  overflow-y: hidden;
+  background-color: #21211f;
+}
+
+.language_controller {
+  height: 100%;
+  max-height: 165px;
+  overflow-y: scroll;
+  background-color: #21211f;
+  margin-left: 10px;
+}
+
+.language_button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 25px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  margin: 0;
+  color: #ffffff;
+}
+
+.language_button:hover {
+  color: #7b7b7b;
+}
+
 .switch {
   position: relative;
   display: inline-block;
@@ -66,8 +107,20 @@ input:checked + .slider:before {
   width: 200px;
   height: 25px;
   padding: 15px;
-  margin: -8px;
-  background: #21211f;
+}
+
+.language_wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 200px;
+  height: 25px;
+  padding: 15px;
+  cursor: pointer;
+}
+
+.language_wrapper:hover {
+  background-color: #7b7b7b;
 }
 
 .container {
@@ -115,4 +168,12 @@ input[type="range"]::-webkit-slider-runnable-track {
   box-shadow: none;
   border: none;
   background: transparent;
+}
+
+.block {
+  display: block;
+}
+
+.hidden {
+  display: none;
 }

--- a/public/popup.html
+++ b/public/popup.html
@@ -4,47 +4,403 @@
     <link rel="stylesheet" type="text/css" href="popup.css" />
   </head>
   <body>
-    <div class="wrapper">
-      <div class="container">
-        <div class="tag">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="24"
-            width="24"
-            fill="#ffffff"
-          >
-            <path
-              d="M5 20q-.825 0-1.413-.587Q3 18.825 3 18V6q0-.825.587-1.412Q4.175 4 5 4h14q.825 0 1.413.588Q21 5.175 21 6v12q0 .825-.587 1.413Q19.825 20 19 20Zm0-2h14V6H5v12Zm2-3h3q.425 0 .713-.288Q11 14.425 11 14v-1H9.5v.5h-2v-3h2v.5H11v-1q0-.425-.287-.713Q10.425 9 10 9H7q-.425 0-.713.287Q6 9.575 6 10v4q0 .425.287.712Q6.575 15 7 15Zm7 0h3q.425 0 .712-.288Q18 14.425 18 14v-1h-1.5v.5h-2v-3h2v.5H18v-1q0-.425-.288-.713Q17.425 9 17 9h-3q-.425 0-.712.287Q13 9.575 13 10v4q0 .425.288.712.287.288.712.288Zm-9 3V6v12Z"
-            />
-          </svg>
-          <span>Subtitle</span>
+    <div class="popup_wrapper">
+      <div class="translate_controller">
+        <div class="wrapper">
+          <div class="container">
+            <div class="tag">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="22"
+                height="22"
+                x="0"
+                y="0"
+                viewBox="0 0 24 24"
+              >
+                <g>
+                  <path
+                    fill="#ffffff"
+                    d="M19 4H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H5V6h14zM7 15h3c.55 0 1-.45 1-1v-1H9.5v.5h-2v-3h2v.5H11v-1c0-.55-.45-1-1-1H7c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1zm7 0h3c.55 0 1-.45 1-1v-1h-1.5v.5h-2v-3h2v.5H18v-1c0-.55-.45-1-1-1h-3c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1z"
+                    data-original="#ffffff"
+                  ></path>
+                </g>
+              </svg>
+              <span>Subtitle</span>
+            </div>
+            <label class="switch">
+              <input id="translate" type="checkbox" />
+              <span class="slider round"></span>
+            </label>
+          </div>
         </div>
-        <label class="switch">
-          <input id="translate" type="checkbox" />
-          <span class="slider round"></span>
-        </label>
+        <div class="wrapper">
+          <div class="container">
+            <div class="tag">
+              <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+              <svg
+                version="1.1"
+                id="svg789"
+                xml:space="preserve"
+                width="20"
+                height="20"
+                viewBox="0 0 682.66669 682.66669"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:svg="http://www.w3.org/2000/svg"
+              >
+                <defs id="defs793">
+                  <clipPath clipPathUnits="userSpaceOnUse" id="clipPath803">
+                    <path d="M 0,512 H 512 V 0 H 0 Z" id="path801" />
+                  </clipPath>
+                </defs>
+                <g
+                  id="g795"
+                  transform="matrix(1.3333333,0,0,-1.3333333,0,682.66667)"
+                >
+                  <g id="g797">
+                    <g id="g799" clip-path="url(#clipPath803)">
+                      <path
+                        d="M 90.925,421.075 H 15 V 497 h 75.925 z"
+                        style="
+                          fill: none;
+                          stroke: #ffffff;
+                          stroke-width: 30;
+                          stroke-linecap: round;
+                          stroke-linejoin: round;
+                          stroke-miterlimit: 10;
+                          stroke-dasharray: none;
+                          stroke-opacity: 1;
+                        "
+                        id="path805"
+                      />
+                      <path
+                        d="M 497,421.075 H 421.075 V 497 H 497 Z"
+                        style="
+                          fill: none;
+                          stroke: #ffffff;
+                          stroke-width: 30;
+                          stroke-linecap: round;
+                          stroke-linejoin: round;
+                          stroke-miterlimit: 10;
+                          stroke-dasharray: none;
+                          stroke-opacity: 1;
+                        "
+                        id="path807"
+                      />
+                      <path
+                        d="M 90.925,15 H 15 v 75.925 h 75.925 z"
+                        style="
+                          fill: none;
+                          stroke: #ffffff;
+                          stroke-width: 30;
+                          stroke-linecap: round;
+                          stroke-linejoin: round;
+                          stroke-miterlimit: 10;
+                          stroke-dasharray: none;
+                          stroke-opacity: 1;
+                        "
+                        id="path809"
+                      />
+                      <path
+                        d="M 497,15 H 421.075 V 90.925 H 497 Z"
+                        style="
+                          fill: none;
+                          stroke: #ffffff;
+                          stroke-width: 30;
+                          stroke-linecap: round;
+                          stroke-linejoin: round;
+                          stroke-miterlimit: 10;
+                          stroke-dasharray: none;
+                          stroke-opacity: 1;
+                        "
+                        id="path811"
+                      />
+                      <g id="g813" transform="translate(459.0376,421.0752)">
+                        <path
+                          d="M 0,0 V -330.15"
+                          style="
+                            fill: none;
+                            stroke: #ffffff;
+                            stroke-width: 30;
+                            stroke-linecap: butt;
+                            stroke-linejoin: round;
+                            stroke-miterlimit: 10;
+                            stroke-dasharray: none;
+                            stroke-opacity: 1;
+                          "
+                          id="path815"
+                        />
+                      </g>
+                      <g id="g817" transform="translate(90.9248,459.0376)">
+                        <path
+                          d="M 0,0 H 330.15"
+                          style="
+                            fill: none;
+                            stroke: #ffffff;
+                            stroke-width: 30;
+                            stroke-linecap: butt;
+                            stroke-linejoin: round;
+                            stroke-miterlimit: 10;
+                            stroke-dasharray: none;
+                            stroke-opacity: 1;
+                          "
+                          id="path819"
+                        />
+                      </g>
+                      <g id="g821" transform="translate(52.9624,90.9248)">
+                        <path
+                          d="M 0,0 V 330.15"
+                          style="
+                            fill: none;
+                            stroke: #ffffff;
+                            stroke-width: 30;
+                            stroke-linecap: butt;
+                            stroke-linejoin: round;
+                            stroke-miterlimit: 10;
+                            stroke-dasharray: none;
+                            stroke-opacity: 1;
+                          "
+                          id="path823"
+                        />
+                      </g>
+                      <g id="g825" transform="translate(421.0752,52.9624)">
+                        <path
+                          d="M 0,0 H -330.15"
+                          style="
+                            fill: none;
+                            stroke: #ffffff;
+                            stroke-width: 30;
+                            stroke-linecap: butt;
+                            stroke-linejoin: round;
+                            stroke-miterlimit: 10;
+                            stroke-dasharray: none;
+                            stroke-opacity: 1;
+                          "
+                          id="path827"
+                        />
+                      </g>
+                    </g>
+                  </g>
+                  <g id="g829" transform="translate(363.4976,305.2935)">
+                    <path
+                      d="M 0,0 V 54.544 H -214.995 V 0"
+                      style="
+                        fill: none;
+                        stroke: #ffffff;
+                        stroke-width: 30;
+                        stroke-linecap: round;
+                        stroke-linejoin: round;
+                        stroke-miterlimit: 10;
+                        stroke-dasharray: none;
+                        stroke-opacity: 1;
+                      "
+                      id="path831"
+                    />
+                  </g>
+                  <g id="g833" transform="translate(256,359.8379)">
+                    <path
+                      d="M 0,0 V -209.676"
+                      style="
+                        fill: none;
+                        stroke: #ffffff;
+                        stroke-width: 30;
+                        stroke-linecap: round;
+                        stroke-linejoin: round;
+                        stroke-miterlimit: 10;
+                        stroke-dasharray: none;
+                        stroke-opacity: 1;
+                      "
+                      id="path835"
+                    />
+                  </g>
+                  <g id="g837" transform="translate(213.0493,150.1621)">
+                    <path
+                      d="M 0,0 H 85.901"
+                      style="
+                        fill: none;
+                        stroke: #ffffff;
+                        stroke-width: 30;
+                        stroke-linecap: round;
+                        stroke-linejoin: round;
+                        stroke-miterlimit: 10;
+                        stroke-dasharray: none;
+                        stroke-opacity: 1;
+                      "
+                      id="path839"
+                    />
+                  </g>
+                </g>
+              </svg>
+
+              <span>Text Size</span>
+            </div>
+            <input
+              value="25"
+              min="10"
+              max="40"
+              type="range"
+              id="font-size-range"
+            />
+          </div>
+        </div>
+        <div class="wrapper">
+          <div class="container">
+            <div class="tag">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                width="20"
+                height="20"
+                viewBox="0 0 512 512"
+                fill="#ffffff"
+              >
+                <g>
+                  <g>
+                    <path
+                      d="M195.708,268.059c-0.821-4.11-29.103-145.52-30-150.001C164.307,111.047,158.15,106,151,106h-30
+          c-7.15,0-13.307,5.047-14.708,12.058c-0.911,4.557-29.222,146.111-30,150c-1.625,8.124,3.644,16.026,11.767,17.65
+          c8.123,1.625,16.026-3.644,17.65-11.767L115.297,226h41.406l9.588,47.942c1.625,8.127,9.531,13.392,17.65,11.767
+          C192.064,284.084,197.333,276.182,195.708,268.059z M121.297,196l12-60h5.406l12,60H121.297z"
+                    />
+                  </g>
+                </g>
+                <g>
+                  <g>
+                    <path
+                      d="M436,226h-45v-15c0-8.284-6.716-15-15-15s-15,6.716-15,15v15h-45c-8.284,0-15,6.716-15,15s6.716,15,15,15h3.63
+          c8.547,27.612,21.415,48.806,35.575,65.79c-11.525,10.542-23.187,19.187-33.575,27.497c-6.469,5.175-7.518,14.614-2.342,21.083
+          c5.178,6.472,14.618,7.515,21.083,2.342c10.446-8.357,22.967-17.644,35.629-29.264c12.671,11.628,25.215,20.932,35.629,29.264
+          c6.469,5.176,15.909,4.126,21.083-2.342c5.175-6.469,4.126-15.909-2.342-21.083c-10.361-8.291-22.038-16.945-33.575-27.497
+          c14.16-16.984,27.028-38.178,35.575-65.79H436c8.284,0,15-6.716,15-15S444.284,226,436,226z M376,299.745
+          c-9.575-12.02-18.189-26.367-24.683-43.845h49.365C394.189,273.378,385.575,287.725,376,299.745z"
+                    />
+                  </g>
+                </g>
+                <g>
+                  <g>
+                    <path
+                      d="M467,91H250.599l-6.43-51.582C241.36,16.946,222.164,0,199.517,0H45C20.187,0,0,20.187,0,45v331c0,24.813,20.187,45,45,45
+          h126.483l6.348,51.582c2.804,22.427,22,39.418,44.653,39.418H467c24.813,0,45-20.187,45-45V136C512,111.187,491.813,91,467,91z
+           M45,391c-8.271,0-15-6.729-15-15V45c0-8.271,6.729-15,15-15h154.517c7.549,0,13.948,5.648,14.883,13.134
+          c2.174,17.436,41.208,330.57,43.364,347.866H45z M206.724,461.75L201.709,421h40.244L206.724,461.75z M482,467
+          c0,8.271-6.729,15-15,15H228.874l57.104-66.053c2.923-3.297,4.233-7.674,3.629-12.024L254.339,121H467c8.271,0,15,6.729,15,15V467
+          z"
+                    />
+                  </g>
+                </g>
+              </svg>
+              <span>Language</span>
+            </div>
+            <button id="language-select-button" class="language_button">
+              Korean
+            </button>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="wrapper">
-      <div class="container">
-        <div class="tag">
+      <div id="language-controller" class="language_controller hidden">
+        <div data-lang="en" class="language_wrapper">
+          <p>English</p>
           <svg
-            width="15"
-            height="15"
+            class="hidden"
             fill="#ffffff"
-            viewBox="0 0 467.765 467.765"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="m175.412 87.706h58.471v29.235h58.471v-87.706h-292.354v87.706h58.471v-29.235h58.471v292.353h-58.471v58.471h175.383v-58.471h-58.442z"
-            />
-            <path
-              d="m233.882 175.412v87.706h58.471v-29.235h29.235v146.176h-29.235v58.471h116.941v-58.471h-29.235v-146.177h29.235v29.235h58.471v-87.706h-233.883z"
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
             />
           </svg>
-          <span>Text Size</span>
         </div>
-        <input value="25" min="10" max="40" type="range" id="font-size-range" />
+        <div data-lang="ko" class="language_wrapper">
+          <p>Korean</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div data-lang="ja" class="language_wrapper">
+          <p>Japanese</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div data-lang="zh" class="language_wrapper">
+          <p>Chinese</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div data-lang="de" class="language_wrapper">
+          <p>German</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div data-lang="es" class="language_wrapper">
+          <p>Spanish</p>
+          <svg
+            class="hidden"
+            height="15"
+            viewBox="0 0 24 24"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="m20.6136 5.64877c.4199.36742.458 1.00751.0845 1.42204l-10.5139 11.66979c-.37544.4167-1.02006.4432-1.42843.0588l-6.08403-5.7276c-.37942-.3572-.41574-.9524-.09021-1.3593.3592-.449 1.02811-.5108 1.4556-.1263l4.72039 4.2459c.41022.369 1.04179.336 1.41138-.0737l9.0435-10.02691c.3659-.40576.99-.44254 1.4012-.08272z"
+              fill="#ffffff"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
       </div>
     </div>
   </body>

--- a/public/popup.ts
+++ b/public/popup.ts
@@ -3,13 +3,22 @@ import {
   setSwitchValueInStorage,
   getFontSizeValueInStorage,
   setFontSizeValueInStorage,
+  getTranslatedTargetLanguageInStorage,
+  setTranslatedTargetLanguageInStorage,
 } from "../src/api/storage";
 import {
   sendMessageToContentRangeValue,
+  sendMessageToContentChangedLanguage,
   sendMessageToContentIsActiveTranslation,
 } from "../src/api/message";
 
 import FontSlider from "../src/view/FontSlider";
+import LanguageSelector from "../src/view/LanguageSelector";
+import LanguageSelectorButton from "../src/view/LanguageSelectorButton";
+
+import { isLanguage } from "../src/common/isLanguage";
+
+import type { LanguageCode } from "../src/common/language.types";
 
 const translationElement = document.getElementById(
   "translate"
@@ -24,6 +33,13 @@ const rangeInputElement = document.querySelector(
 ) as HTMLInputElement;
 
 const FontSliderInstance = new FontSlider(rangeElement);
+const LanguageSelectorInstance = new LanguageSelector();
+const LanguageSelectorButtonInstance = new LanguageSelectorButton();
+
+const languageSelectorWrapperElement =
+  LanguageSelectorInstance.getLanguageSelectorWrapperElement();
+const languageSelectorButtonElement =
+  LanguageSelectorButtonInstance.getLanguageSelectorButtonElement();
 
 const setInitialSwitchState = async () => {
   const isChecked = await getSwitchValueInStorage();
@@ -47,6 +63,58 @@ const setFontRangeStyleAndStorageValue = async (rangeValue: number) => {
 
   FontSliderInstance.setFontRangeStyle(rangeValue);
 };
+
+const setInitialLanguageSelectorValue = async () => {
+  const language = (await getTranslatedTargetLanguageInStorage()) ?? "ko";
+  const languageCode = isLanguage(language) ? language : "ko";
+
+  LanguageSelectorInstance.toggleCheckLanguage(languageCode);
+};
+
+const setInitialLanguageSelectorText = async () => {
+  const language = (await getTranslatedTargetLanguageInStorage()) ?? "ko";
+  const languageCode = isLanguage(language) ? language : "ko";
+
+  LanguageSelectorButtonInstance.setLanguageSelectorButtonText(languageCode);
+};
+
+languageSelectorWrapperElement.addEventListener("click", async (event) => {
+  const target = event.target as HTMLDivElement;
+  const selectedLangDataAttribute = target.dataset.lang;
+  const prevLanguageCode =
+    (await getTranslatedTargetLanguageInStorage()) ?? "ko";
+
+  if (selectedLangDataAttribute === prevLanguageCode) return;
+
+  if (prevLanguageCode) {
+    const validatedPrevLanguageCode: LanguageCode = isLanguage(prevLanguageCode)
+      ? prevLanguageCode
+      : "ko";
+
+    LanguageSelectorInstance.toggleCheckLanguage(validatedPrevLanguageCode);
+  }
+
+  if (selectedLangDataAttribute) {
+    const languageCode: LanguageCode = isLanguage(selectedLangDataAttribute)
+      ? selectedLangDataAttribute
+      : "ko";
+
+    LanguageSelectorInstance.toggleCheckLanguage(languageCode);
+
+    await setTranslatedTargetLanguageInStorage(languageCode);
+
+    LanguageSelectorButtonInstance.setLanguageSelectorButtonText(languageCode);
+
+    await sendMessageToContentChangedLanguage(languageCode);
+  }
+
+  LanguageSelectorInstance.toggleLanguageSelectorDisplay();
+});
+
+languageSelectorButtonElement.addEventListener(
+  "click",
+  LanguageSelectorInstance.toggleLanguageSelectorDisplay
+);
 
 translationElement.addEventListener("click", async () => {
   const isChecked = translationElement.checked;
@@ -76,3 +144,5 @@ chrome.runtime.onMessage.addListener(async (request: { message: string }) => {
 // when popup open set default switch state
 setInitialSwitchState();
 setInitialFontRangeSlider();
+setInitialLanguageSelectorText();
+setInitialLanguageSelectorValue();

--- a/src/api/message/Message.ts
+++ b/src/api/message/Message.ts
@@ -1,6 +1,13 @@
+import type { LanguageCode } from "../../common/language.types";
+
+type ChromeAPIPayload = {
+  translateTargetText: string;
+  languageCode: LanguageCode;
+};
+
 export type ChromeAPIRequest = {
   message: string;
-  payload: string;
+  payload: ChromeAPIPayload;
 };
 
 export type ChromeAPIResponse = {
@@ -19,7 +26,7 @@ const Message = {
 
   async sendMessageToBackground(
     message: string,
-    payload: string,
+    payload: ChromeAPIPayload,
     callback: (response: ChromeAPIResponse) => void
   ) {
     chrome.runtime.sendMessage<ChromeAPIRequest, ChromeAPIResponse>(

--- a/src/api/message/index.ts
+++ b/src/api/message/index.ts
@@ -3,17 +3,20 @@ import Message from "./Message";
 import {
   TRANSLATE_CALL_MESSAGE,
   FONT_SIZE_RANGE_MESSAGE,
+  CHANGE_LANGUAGE_MESSAGE,
 } from "../../common/const";
 
+import type { LanguageCode } from "../../common/language.types";
 import type { ChromeAPIRequest, ChromeAPIResponse } from "./Message";
 
 const sendMessageToBackgroundTranslatingText = async (
   translateTargetText: string,
+  languageCode: LanguageCode,
   callback: (text: string) => void
 ) => {
   await Message.sendMessageToBackground(
     "translate",
-    translateTargetText,
+    { translateTargetText, languageCode },
     (response) => {
       const translatedText = response.data;
 
@@ -52,10 +55,24 @@ const sendMessageToContentRangeValue = async (rangeValue: number) => {
   );
 };
 
+const sendMessageToContentChangedLanguage = async (language: LanguageCode) => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const tabId = tab.id;
+
+  if (!tabId) return;
+
+  await Message.sendMessageToContentScript(
+    tabId,
+    CHANGE_LANGUAGE_MESSAGE,
+    language
+  );
+};
+
 export {
   sendMessageToBackgroundTranslatingText,
   sendMessageToContentIsActiveTranslation,
   sendMessageToContentRangeValue,
+  sendMessageToContentChangedLanguage,
 };
 
 export type { ChromeAPIRequest, ChromeAPIResponse };

--- a/src/api/storage/index.ts
+++ b/src/api/storage/index.ts
@@ -30,9 +30,25 @@ const setFontSizeValueInStorage = async (fontSize: number) => {
   await Storage.setStorageValue(FONT_SIZE_STORAGE_KEY, fontSize);
 };
 
+const getTranslatedTargetLanguageInStorage = async () => {
+  const { language } = await Storage.getStorageValue<string | unknown>(
+    "language"
+  );
+
+  if (typeof language !== "string") return;
+
+  return language;
+};
+
+const setTranslatedTargetLanguageInStorage = async (language: string) => {
+  await Storage.setStorageValue("language", language);
+};
+
 export {
   getSwitchValueInStorage,
   setSwitchValueInStorage,
   getFontSizeValueInStorage,
   setFontSizeValueInStorage,
+  getTranslatedTargetLanguageInStorage,
+  setTranslatedTargetLanguageInStorage,
 };

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,10 +5,9 @@ const replaceNewLineSequenceToSpace = (text: string) => {
 chrome.runtime.onMessage.addListener(({ message, payload }, _, response) => {
   if (message === "translate") {
     const translateTargetText = encodeURIComponent(
-      replaceNewLineSequenceToSpace(payload)
+      replaceNewLineSequenceToSpace(payload.translateTargetText)
     );
-    const apiURL = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=ko&dt=t&q=${translateTargetText}`;
-
+    const apiURL = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=${payload.languageCode}&dt=t&q=${translateTargetText}`;
     fetch(apiURL)
       .then((res) => {
         if (res.status !== 200) {

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -1,4 +1,5 @@
 export const TRANSLATE_CALL_MESSAGE = "render";
+export const CHANGE_LANGUAGE_MESSAGE = "changeLanguage";
 export const FONT_SIZE_RANGE_MESSAGE = "fontSizeRange";
 export const SWITCH_STORAGE_KEY = "isChecked";
 export const FONT_SIZE_STORAGE_KEY = "fontSize";

--- a/src/common/isLanguage.ts
+++ b/src/common/isLanguage.ts
@@ -1,0 +1,5 @@
+import type { LanguageCode } from "./language.types";
+
+export const isLanguage = (language: string): language is LanguageCode => {
+  return ["en", "ko", "zh", "es", "ja", "de"].includes(language);
+};

--- a/src/common/language.types.ts
+++ b/src/common/language.types.ts
@@ -1,0 +1,1 @@
+export type LanguageCode = "en" | "ko" | "zh" | "es" | "ja" | "de";

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -3,6 +3,8 @@ import Model from "../model";
 
 import { sendMessageToBackgroundTranslatingText } from "../api/message";
 
+import type { LanguageCode } from "../common/language.types";
+
 class Controller {
   _view: View;
   _model: Model;
@@ -34,6 +36,7 @@ class Controller {
     const isSameTargetElementAndText = this.checkIsSameTargetElementAndText();
 
     const textContent = this._view.getTextContent();
+    const translatedLanguageCode = this._model.getLanguageCode();
 
     if (!textContent || isSameTargetElementAndText) return;
 
@@ -49,6 +52,7 @@ class Controller {
 
     await sendMessageToBackgroundTranslatingText(
       textContent,
+      translatedLanguageCode,
       deletePrevElementEndRender
     );
   }
@@ -56,6 +60,10 @@ class Controller {
   changeFontSizeRangeElement(value: number) {
     this._model.setFontSize(value);
     this._view.setClosedCaptionFontSize(value);
+  }
+
+  changeLanguageCodeElement(languageCode: LanguageCode) {
+    this._model.setLanguageCode(languageCode);
   }
 
   deleteTranslatedElement() {

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,9 +1,13 @@
+import type { LanguageCode } from "../common/language.types";
+
 class Model {
   fontSize: number;
+  languageCode: LanguageCode;
   targetOfTranslatingText: string;
 
   constructor() {
     this.fontSize = 25;
+    this.languageCode = "ko";
     this.targetOfTranslatingText = "";
   }
 
@@ -21,6 +25,14 @@ class Model {
 
   getFontSize() {
     return this.fontSize;
+  }
+
+  setLanguageCode(languageCode: LanguageCode) {
+    this.languageCode = languageCode;
+  }
+
+  getLanguageCode() {
+    return this.languageCode;
   }
 }
 

--- a/src/view/LanguageSelector.ts
+++ b/src/view/LanguageSelector.ts
@@ -1,0 +1,40 @@
+import type { LanguageCode } from "../common/language.types";
+
+class LanguageSelector {
+  languageSelectorWrapper: HTMLDivElement;
+
+  constructor() {
+    this.languageSelectorWrapper = document.getElementById(
+      "language-controller"
+    ) as HTMLDivElement;
+  }
+
+  getSelectedLanguage = () => {
+    const selectedLanguage = this.languageSelectorWrapper.querySelector(
+      ".selected"
+    ) as HTMLDivElement;
+
+    return selectedLanguage;
+  };
+
+  getLanguageSelectorWrapperElement = () => {
+    return this.languageSelectorWrapper;
+  };
+
+  toggleLanguageSelectorDisplay = () => {
+    this.languageSelectorWrapper.classList.toggle("hidden");
+  };
+
+  toggleCheckLanguage = (targetLanguage: LanguageCode) => {
+    const targetLanguageElement = document.querySelector(
+      `[data-lang="${targetLanguage}"]`
+    ) as HTMLDivElement | null;
+
+    if (!targetLanguageElement) return;
+
+    targetLanguageElement.children[1].classList.toggle("hidden");
+    targetLanguageElement.children[1].classList.toggle("selected");
+  };
+}
+
+export default LanguageSelector;

--- a/src/view/LanguageSelectorButton.ts
+++ b/src/view/LanguageSelectorButton.ts
@@ -1,0 +1,55 @@
+import type { LanguageCode } from "../common/language.types";
+
+class LanguageSelectorButton {
+  private readonly languageSelectorButton: HTMLButtonElement;
+
+  constructor() {
+    this.languageSelectorButton = document.getElementById(
+      "language-select-button"
+    ) as HTMLButtonElement;
+  }
+
+  getLanguageSelectorButtonElement = () => {
+    return this.languageSelectorButton;
+  };
+
+  getLanguageSelectorButtonText = () => {
+    return this.languageSelectorButton.textContent;
+  };
+
+  setLanguageSelectorButtonText = (language: LanguageCode) => {
+    switch (language) {
+      case "ko": {
+        this.languageSelectorButton.textContent = "Korean";
+        break;
+      }
+      case "en": {
+        this.languageSelectorButton.textContent = "English";
+        break;
+      }
+      case "zh": {
+        this.languageSelectorButton.textContent = "Chinese";
+        break;
+      }
+      case "es": {
+        this.languageSelectorButton.textContent = "Spanish";
+        break;
+      }
+      case "de": {
+        this.languageSelectorButton.textContent = "German";
+        break;
+      }
+      case "ja": {
+        this.languageSelectorButton.textContent = "Japanese";
+        break;
+      }
+
+      default: {
+        this.languageSelectorButton.textContent = "Korean";
+        break;
+      }
+    }
+  };
+}
+
+export default LanguageSelectorButton;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = {
           globOptions: { ignore: ["**/readme/**"] },
         },
         { from: "./public/manifest.json", to: "./manifest.json" },
+        { from: "./public/popup.css", to: "./popup.css" },
       ],
     }),
     new MiniCssExtractPlugin({ filename: "popup.css" }),


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 기존 한국어만 지원하는 기능에서 독일어, 일본어, 영어, 스페인어, 중국어로 번역 가능하도록 기능 구현했습니다.

- 기타 참고 문서 : https://cloud.google.com/translate/docs/languages

## 💻 Changes

popup 에서 번역 변경 버튼, Selector html css 를 추가했습니다. f6ac1d2

language code type 및 type guard util function 을 추가했습니다. 7108b5a

LanguageSelector, Button View Class 를 추가했습니다. b1edbb1

Language 변경과 관련된 message, background 등에 대한 util function 추가 및 업데이트를 진행했습니다. 854ec28

controller, model 에서 language 업데이트 관련 코드를 추가했습니다. 397c8c1

popup 에서 업데이트, message passing 로직을 구현했습니다. 47275b0

## 🎥 ScreenShot or Video

https://user-images.githubusercontent.com/64253365/224491813-0b263f75-c742-4253-94dc-f107a0297d27.mov


